### PR TITLE
Added Updated On and Fixed Issue in Header and Data of Listing Page

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -161,6 +161,14 @@
                                     "attributes":{
                                         "type":"object",
                                         "additionalProperties":true
+                                    },
+                                    "created_on": {
+                                        "type":"string",
+                                        "format":"date-time"
+                                    },
+                                    "modified_on": {
+                                        "type":"string",
+                                        "format":"date-time"
                                     }
                                 }
                             }

--- a/templatestore/frontend/src/pages/home.js
+++ b/templatestore/frontend/src/pages/home.js
@@ -18,6 +18,7 @@ class Home extends Component {
             'type',
             'default_version',
             'created_on',
+            'updated_on',
             ...this.props.fixedAttributeKeys
         ];
         this.getTableRowsJSX = this.getTableRowsJSX.bind(this);
@@ -33,9 +34,10 @@ class Home extends Component {
                         template_name: t.name,
                         default_version: t.default ? t.version : '-',
                         type: t.type,
-                        created_on: getDateInSimpleFormat(t.created_on)
+                        created_on: getDateInSimpleFormat(t.created_on),
+                        updated_on: getDateInSimpleFormat(t.modified_on),
                     },
-                    ...this.tableHeaderList.slice(4).reduce((result, k) => {
+                    ...this.tableHeaderList.slice(5).reduce((result, k) => {
                         result[k] = t.attributes[k];
                         return result;
                     }, {})

--- a/templatestore/frontend/src/pages/home.js
+++ b/templatestore/frontend/src/pages/home.js
@@ -32,8 +32,8 @@ class Home extends Component {
                 templatesData: response.data.map(t => ({
                     ...{
                         template_name: t.name,
-                        default_version: t.default ? t.version : '-',
                         type: t.type,
+                        default_version: t.default ? t.version : '-',
                         created_on: getDateInSimpleFormat(t.created_on),
                         updated_on: getDateInSimpleFormat(t.modified_on),
                     },

--- a/templatestore/views.py
+++ b/templatestore/views.py
@@ -82,7 +82,9 @@ def get_templates_view(request):
             offset = int(request.GET.get("offset", 0))
             limit = int(request.GET.get("limit", ts_settings.TE_ROWLIMIT))
 
-            templates = Template.objects.all().order_by("-modified_on")[offset : offset + limit]
+            templates = Template.objects.all().order_by("-modified_on")[
+                offset : offset + limit
+            ]
             template_list = [
                 {
                     "name": t.name,
@@ -95,7 +97,7 @@ def get_templates_view(request):
                     "type": t.type,
                     "attributes": t.attributes,
                     "created_on": t.created_on,
-                    "modified_on": t.modified_on
+                    "modified_on": t.modified_on,
                 }
                 for t in templates
             ]

--- a/templatestore/views.py
+++ b/templatestore/views.py
@@ -95,6 +95,7 @@ def get_templates_view(request):
                     "type": t.type,
                     "attributes": t.attributes,
                     "created_on": t.created_on,
+                    "modified_on": t.modified_on
                 }
                 for t in templates
             ]

--- a/templatestore/views.py
+++ b/templatestore/views.py
@@ -82,7 +82,7 @@ def get_templates_view(request):
             offset = int(request.GET.get("offset", 0))
             limit = int(request.GET.get("limit", ts_settings.TE_ROWLIMIT))
 
-            templates = Template.objects.all()[offset : offset + limit]
+            templates = Template.objects.all().order_by("-modified_on")[offset : offset + limit]
             template_list = [
                 {
                     "name": t.name,


### PR DESCRIPTION
1 - Added Updated_on Column in Listing Page.
2 - Sorted according to decreasing order of Updated_on.
3 - Earlier there was an issue between header and data of the listing page (i.e Type column had default_version values and vice versa). It is fixed now.