### PR TITLE
Removing Save Button in New Template Creation Screen

### DIFF
--- a/templatestore/frontend/src/pages/templateScreen.js
+++ b/templatestore/frontend/src/pages/templateScreen.js
@@ -557,21 +557,25 @@ class TemplateScreen extends Component {
                     }
                 </div>
                 <div>
-                    <button
-                        className={styles.teButtons}
-                        onClick={() => {
-                            if (window.confirm('Are you sure ?')) { // eslint-disable-line no-alert
-                                this.postTemplate(
-                                    this.state.templateData.name,
-                                    this.state.type,
-                                    this.state.contextData,
-                                    this.state.attributes
-                                );
-                            }
-                        }}
-                    >
-                         Save
-                    </button>
+                    {this.state.editable ? (
+                        ''
+                    ) : (
+                        <button
+                            className={styles.teButtons}
+                            onClick={() => {
+                                if (window.confirm('Are you sure ?')) { // eslint-disable-line no-alert
+                                    this.postTemplate(
+                                        this.state.templateData.name,
+                                        this.state.type,
+                                        this.state.contextData,
+                                        this.state.attributes
+                                    );
+                                }
+                            }}
+                        >
+                             Save
+                        </button>
+                    )}
                 </div>
                 <div className={styles.teSearchWrapper}>
                     {this.state.editable ? (


### PR DESCRIPTION
Save button is used to save the updated template with an updated version. This button should not be present in the New Template Creation Screen. It is fixed now.