### PR TITLE
Props Type Validation

### DIFF
--- a/templatestore/frontend/package.json
+++ b/templatestore/frontend/package.json
@@ -32,6 +32,7 @@
     "axios": "^0.19.2",
     "compression-webpack-plugin": "^4.0.0",
     "file-loader": "^5.0.2",
+    "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-ace": "^8.0.0",
     "react-ace-builds": "^7.3.0",

--- a/templatestore/frontend/src/components/SearchBox/index.js
+++ b/templatestore/frontend/src/components/SearchBox/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import styles from './searchBox.less';
 
 class SearchBox extends React.Component {
@@ -22,5 +22,7 @@ class SearchBox extends React.Component {
         );
     }
 }
-
+SearchBox.propTypes = {
+    onChange: PropTypes.func
+};
 export default SearchBox;

--- a/templatestore/frontend/src/components/SearchBox/index.js
+++ b/templatestore/frontend/src/components/SearchBox/index.js
@@ -22,7 +22,9 @@ class SearchBox extends React.Component {
         );
     }
 }
+
 SearchBox.propTypes = {
     onChange: PropTypes.func
 };
+
 export default SearchBox;

--- a/templatestore/frontend/src/components/searchBox.js
+++ b/templatestore/frontend/src/components/searchBox.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class SearchBox extends React.Component {
     constructor(props) {
@@ -13,5 +14,8 @@ class SearchBox extends React.Component {
         return <input type="text" onChange={this.onChange.bind(this)} />;
     }
 }
+SearchBox.propTypes = {
+    onChange: PropTypes.func
+};
 
 export default SearchBox;

--- a/templatestore/frontend/src/components/searchBox.js
+++ b/templatestore/frontend/src/components/searchBox.js
@@ -14,6 +14,7 @@ class SearchBox extends React.Component {
         return <input type="text" onChange={this.onChange.bind(this)} />;
     }
 }
+
 SearchBox.propTypes = {
     onChange: PropTypes.func
 };

--- a/templatestore/frontend/src/pages/home.js
+++ b/templatestore/frontend/src/pages/home.js
@@ -5,6 +5,7 @@ import styles from './../style/home.less';
 import { backendSettings, getDateInSimpleFormat } from './../utils.js';
 import SearchBox from './../components/searchBox/index';
 import Highlight from './../components/highlight.js';
+import PropTypes from 'prop-types';
 
 class Home extends Component {
     constructor(props) {
@@ -164,5 +165,12 @@ class Home extends Component {
         );
     }
 }
+
+Home.propTypes = {
+    history: PropTypes.shape({
+        push: PropTypes.func
+    }),
+    fixedAttributeKeys: PropTypes.arrayOf(PropTypes.string)
+};
 
 export default withRouter(Home);

--- a/templatestore/frontend/src/pages/templateScreen.js
+++ b/templatestore/frontend/src/pages/templateScreen.js
@@ -7,6 +7,7 @@ import {
     backendSettings,
     getDateInSimpleFormat
 } from './../utils.js';
+import PropTypes from 'prop-types';
 import styles from './../style/templateScreen.less';
 import SearchBox from './../components/searchBox/index';
 import Highlight from './../components/highlight.js';
@@ -845,5 +846,18 @@ class TemplateScreen extends Component {
         );
     }
 }
+
+TemplateScreen.propTypes = {
+    match: PropTypes.shape({
+        params: PropTypes.shape({
+            name: PropTypes.string,
+            version: PropTypes.string
+        })
+    }),
+    history: PropTypes.shape({
+        push: PropTypes.func
+    }),
+    editable: PropTypes.bool
+};
 
 export default withRouter(TemplateScreen);


### PR DESCRIPTION
Earlier, we received warnings because we were not validating types of props received. Now these warnings are removed.