### PR TITLE
fixed table header

### DIFF
--- a/templatestore/frontend/src/style/home.less
+++ b/templatestore/frontend/src/style/home.less
@@ -1,3 +1,4 @@
+table
 
 .tsTable {
      margin: 40px 40px;
@@ -13,8 +14,11 @@
           height: 80vh;
           overflow: auto;
           margin-top: 15px;
-          thead {
-               background-color: #dedede;
+          thead tr th {
+              background-color: #dedede;
+              position: sticky;
+              z-index: 100;
+              top: 0;
           }
           tbody {
                height: 400px;

--- a/templatestore/frontend/src/style/home.less
+++ b/templatestore/frontend/src/style/home.less
@@ -1,5 +1,3 @@
-table
-
 .tsTable {
      margin: 40px 40px;
      box-shadow: 2px 2px 6px #000000;

--- a/templatestore/frontend/src/style/templateScreen.less
+++ b/templatestore/frontend/src/style/templateScreen.less
@@ -107,8 +107,11 @@
     overflow: auto;
     margin: 5px 0 100px 0;
     table {
-        thead {
+        thead tr th {
             background-color: #dedede;
+            position: sticky;
+            z-index: 100;
+            top: 0;
        }
         button {
             border-radius: 5px;


### PR DESCRIPTION
Currently when we scroll the Home Screen Table or the Versions table on the template details page, the header also gets scrolled. But this will fix that. Header will remain fixed at its position even on scrolling it.